### PR TITLE
Allow failed queues to be scraped

### DIFF
--- a/stats.py
+++ b/stats.py
@@ -1,5 +1,6 @@
-import os, redis
-from rq import Worker, Queue, Connection
+import os
+import redis
+from rq import Worker, Queue, Connection, version as rq_version
 
 CONN = redis.from_url(os.getenv('RQ_REDIS_URI'))
 
@@ -7,10 +8,12 @@ def scrape():
     enqueued_jobs = []
     workers = []
 
-    enqueued_jobs = [
-        dict(queue_name=q.name, size=q.count)
-        for q in Queue.all(connection=CONN)
-    ]
+    queues = Queue.all(connection=CONN)
+    enqueued_jobs = [dict(queue_name=q.name, size=q.count) for q in queues]
+    if rq_version.VERSION.startswith("1"):
+        enqueued_jobs.extend([
+            dict(queue_name=f"{q.name}-failed", size=q.failed_job_registry.count) for q in queues
+        ])
 
     workers = [
         dict(name=w.name, queues=_serialize_queue_names(w), state=str(w.get_state()))

--- a/stats_test.py
+++ b/stats_test.py
@@ -14,5 +14,5 @@ def test_stat_scrape():
     worker.register_birth()
 
     jobs, workers = stats.scrape()
-    assert jobs == [{"queue_name": "echo", "size": 2}]
+    assert jobs == [{"queue_name": "echo", "size": 2}, {"queue_name": "echo-failed", "size": 0}]
     assert workers == [{"name": "test_worker", "queues": "searches,test", "state": "?"}]


### PR DESCRIPTION
Since `rq` [version 1.0](https://github.com/rq/rq/releases/tag/v1.0), the `FailedQueue` has been replaced with `FailedJobRegistry` for each queue instead. This PR allows the `FailedJobRegistry` for each queue to be recognized as a separate queue.